### PR TITLE
fix typo in synopsis

### DIFF
--- a/lib/Mojolicious/Plugin/CHI.pm
+++ b/lib/Mojolicious/Plugin/CHI.pm
@@ -93,7 +93,7 @@ Mojolicious::Plugin::CHI - Use CHI caches within Mojolicious
       root_dir   => '/cache',
       cache_size => '20m'
     }
-  );
+  });
 
   # Mojolicious::Lite
   plugin 'CHI' => {


### PR DESCRIPTION
A curly bracket is missing in the synopsis of the docs.
Should get fixed, because usually people copy&paste this stuff and then run into errors which are unnecessary. (like it happened to me ;-) )

Regards
Boris
